### PR TITLE
replacing clones in pattern sheets by InkScape connectors

### DIFF
--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -39,7 +39,7 @@ class Pattern (m:String, tileType: String, rows: Int, cols: Int,
 
   def createTag: String = {
     val link = "https://d-bl.github.io/GroundForge/index.html" +
-      "?matrix=" + m.grouped(cols).toArray.mkString("%0D") + s"&tiles=$tileType"
+      "?matrix=" + m.grouped(cols).toArray.mkString("%0D") + s"&amp;tiles=$tileType"
     s"""
       |<text style='font-family:Arial;font-size:11pt'>
       | <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType, $hXw, $m</tspan>

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation.JSExport
   */
 @JSExport
 case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' width='210mm'") {
-  private val nameSpaces = "xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg'"
+  private val nameSpaces = "xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape'"
   private val patterns = new ListBuffer[Pattern]
 
   @JSExport

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -25,5 +25,5 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
   @JSExport // parentheses are required for JavaScript
   def toSvgDoc():String = s"${s"<svg version='1.1' id='svg2' $pageSize $nameSpaces>"}\n$toSvgGroups\n</svg>"
   def toList: List[Pattern] = patterns.toList
-  def toSvgGroups: String = patterns.map(_.patch).mkString("")
+  def toSvgGroups: String = patterns.map(_.patch()).mkString("")
 }

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -15,7 +15,7 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
   def add(m: String, tileType: String): PatternSheet = {
     val n = patterns.size
     val x = 70 + (n / patchRows) * 360
-    val y = 120 + (n % patchRows) * 335
+    val y = 90 + (n % patchRows) * 335
     val lines = Matrix.toMatrixLines(m).get
     patterns.append(new Pattern(lines.mkString(""), tileType, lines.length, lines(0).length, s"GFP$n", x, y))
     this

--- a/src/main/scala/dibl/TileType.scala
+++ b/src/main/scala/dibl/TileType.scala
@@ -20,6 +20,14 @@ abstract class TileType {
   // TODO add method(s) for Pattern class
 
   def toChecker(m: M): M
+
+  /** @param row row number in the generated patch
+    * @param col col number in the generated patch
+    * @param rows height of the matrix that defines the pattern
+    * @param cols width of the matrix that defines the pattern
+    * @return reduced values for (row,col)
+    */
+  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int)
 }
 
 object TileType {
@@ -36,6 +44,12 @@ object Checker extends TileType {
     }
 
   def toChecker(m: M): M = m
+
+  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
+    val c = col % cols
+    val r = row % rows
+    (r,c)
+  }
 }
 
 object Brick extends TileType {
@@ -46,6 +60,13 @@ object Brick extends TileType {
         ((row - margin + relRows) % relRows, (brickOffset + col) % relCols)
       }
     }
+
+  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
+    val offset = (row / rows % 2) * (cols / 2)
+    val c = (col + offset) % cols
+    val r = row % rows
+    (r,c)
+  }
 
   /** Creates a checkerboard-matrix from a brick-matrix by
     * adding two half bricks to the bottom of the brick-matrix.

--- a/src/test/scala/dibl/PatternSpec.scala
+++ b/src/test/scala/dibl/PatternSpec.scala
@@ -47,8 +47,8 @@ class PatternSpec extends FlatSpec with Matchers {
     patterns.add("66,99+22\n00", "bricks")
     val svgString = patterns.toSvgDoc()
     val links = svgString.split("\n").filter(_.contains("href='http")).mkString("\n")
-    links should include ("?matrix=88%0D11&tiles=bricks'")
-    links should include ("?matrix=66%0D99%0D22%0D00&tiles=bricks'")
+    links should include ("?matrix=88%0D11&amp;tiles=bricks'")
+    links should include ("?matrix=66%0D99%0D22%0D00&amp;tiles=bricks'")
   }
 
   it should "produce a single patch" in {


### PR DESCRIPTION
@Neon22

I'm trying to rewrite the pattern sheets using InkScape connectors. Nodes that should be moved together have the same color. InkScape has a 'select same' in the popup of a selected object. That makes adjusting a pattern a piece of cake: select a node, right click, select same fill and nudge the nodes. To make selecting nodes easier: select one, then select same object types and raise them to top.

I attached a sample. I don't understand why InkScape resets so many path coordinates to (0,0) when loading the file, to change them again when ungrouping. Each comment line in the svg file precedes a node and its incoming links. The node IDs reflects its row and column.

[pattern-sheet.zip](https://github.com/d-bl/GroundForge/files/435489/pattern-sheet.zip)

