### PR TITLE
Restore cloned pattern sheets

### DIFF
--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -15,7 +15,7 @@
 */
 package dibl
 
-import dibl.Matrix.{toAbsWithMargins, toMatrixLines, toRelSrcNodes}
+import dibl.Matrix.{toMatrixLines, toRelSrcNodes}
 
 import scala.collection.immutable.IndexedSeq
 import scala.util.Try
@@ -35,9 +35,6 @@ object Pattern {
     val triedSVG = for {
       lines <- toMatrixLines(tileMatrix)
       relative <- toRelSrcNodes(tileMatrix)
-      rows = lines.length
-      cols = lines(0).length
-      absolute <- toAbsWithMargins(relative, rows, cols)
     } yield new Pattern(
       tileMatrix,
       tileType,
@@ -45,8 +42,7 @@ object Pattern {
       offsetX,
       offsetY,
       lines,
-      relative,
-      absolute
+      relative
     ).createPatch
 
     triedSVG.getOrElse(failureMessage(triedSVG))
@@ -59,8 +55,7 @@ private class Pattern (tileMatrix: String,
                        offsetX: Int = 80,
                        offsetY: Int = 120,
                        lines: Array[String],
-                       relative: M,
-                       absolute: M
+                       relative: M
                       ){
 
   val tt = TileType(tileType)
@@ -130,9 +125,9 @@ private class Pattern (tileMatrix: String,
       )
 
   def clones: String = {
-    val brickOffset = if (tileType == "bricks") tileCols * 5 else 0
+    val brickOffset = if (tileType == "bricks") tileCols * 5 else 0 // TODO refactor into TileType
     def cloneRows(row1: Int): String = {
-      val row2 = row1 + tileRows * 10 // TODO refactor into TileType
+      val row2 = row1 + tileRows * 10
       List.range(start = -(if (tileType == "bricks")brickOffset else 10*tileCols), end = 200, step = tileCols * 10).
         map(w => {
           clone(w, row1) + clone(w - brickOffset, row2)

--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -17,38 +17,64 @@ package dibl
 
 import dibl.Matrix.{toAbsWithMargins, toRelSrcNodes}
 
-class Pattern (m:String, tileType: String, rows: Int, cols: Int,
-               groupId: String = "GFP1", offsetX: Int = 80, offsetY: Int = 120) {
+abstract class Pattern (m:String,
+                        tileType: String,
+                        rows: Int,
+                        cols: Int,
+                        groupId: String = "GFP1",
+                        offsetX: Int = 80,
+                        offsetY: Int = 120) {
 
   require(rows * cols == m.length, "invalid matrix dimensions")
+  require(offsetX > 0 && offsetY > 0, "invalid patch dimensions")
 
-  private val hXw = s"${rows}x$cols"
+  protected val hXw = s"${rows}x$cols"
   private val tt = TileType(tileType)
 
-  def patch(rows: Int = 22, cols: Int = 22): String = {
+  protected def toX(col: Int): Int = col * 10 + offsetX
+  protected def toY(row: Int): Int = row * 10 + offsetY
+  protected def toNodeId(row: Int, col: Int): String = s"${groupId}r${row}c$col"
+  protected def toColor(row: Int, col: Int): String = {
+    val (r,c) = tt.toOriginal(row, col, rows, cols)
+    f"00${c * (256/cols)}%02X${r * (256/rows)}%02X"
+  }
 
-    require(offsetX > 0 && offsetY > 0, "invalid patch dimensions")
-
-    (for {
+  def patch(rows: Int = 22, cols: Int = 22): String = (
+    for {
       relative <- toRelSrcNodes(matrix = m, dimensions = hXw)
       checker = tt.toChecker(relative)
       absolute <- toAbsWithMargins(checker, rows, cols)
-      q = "matrix=" + m.grouped(this.cols).toArray.mkString("%0D") + s"&amp;tiles=$tileType"
-      url = "https://d-bl.github.io/GroundForge/index.html"
-    } yield
-      s"""<g>
-         |  <text style='font-family:Arial;font-size:11pt'>
-         |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType, $hXw, $m</tspan>
-         |   <tspan x='${offsetX + 15}' y='${offsetY -  0}' style='fill:#008;'>
-         |    <a xlink:href='$url?$q'>pair/thread diagrams</a>
-         |   </tspan>
-         |  </text>
-         |  ${createDiagram(absolute)}
-         |</g>
-         |""".stripMargin
-    ).get}
+    } yield absolute
+    ).map(createGroup).getOrElse("whoops")
 
-  def createDiagram(m: M): String = {
+  protected def createGroup(m: M): String = {
+    val q = s"matrix=${this.m}&amp;tiles=$tileType"
+    val url = "https://d-bl.github.io/GroundForge/index.html"
+    s"""<g>
+       |  <text style='font-family:Arial;font-size:11pt'>
+       |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType, $hXw, $m</tspan>
+       |   <tspan x='${offsetX + 15}' y='${offsetY - 0}' style='fill:#008;'>
+       |    <a xlink:href='$url?$q'>pair/thread diagrams</a>
+       |   </tspan>
+       |  </text>
+       |  ${createDiagram(m)}
+       |</g>
+       |""".stripMargin
+  }
+
+  protected def createDiagram(absolute: M): String
+}
+
+case class ConnectedPattern(m: String,
+                            tileType: String,
+                            rows: Int,
+                            cols: Int,
+                            groupId: String = "GFP1",
+                            offsetX: Int = 80,
+                            offsetY: Int = 120)
+  extends Pattern(m, tileType, rows, cols, groupId, offsetX, offsetY) {
+
+  def createDiagram(m: M) = {
     def createNode(row: Int, col: Int) =
       s"""  <circle
          |    style='fill:#${toColor(row, col)};stroke:none'
@@ -62,11 +88,13 @@ class Pattern (m:String, tileType: String, rows: Int, cols: Int,
     def createTwoIn(row: Int, col: Int): String = {
       val srcNodes = m(row)(col)
       def createPath(start: (Int, Int)): String = {
-        val (startRow, startCol) = start
-        if (m(startRow)(startCol).isEmpty) "" else
+        val (startRow,
+        startCol) = start
+        if (m(startRow)(
+          startCol).isEmpty) "" else
           s"""  <path
              |    style='stroke:#000000;fill:none'
-             |    d='M ${toX(startCol)},${toY(startRow)} ${toX(col)},${toY(row)}'
+             |    d='M ${toX(startCol)},${toY(startRow)} ${toX (col)},${toY(row)}'
              |    inkscape:connector-type='polyline'
              |    inkscape:connector-curvature='0'
              |    inkscape:connection-start='#${toNodeId(startRow, startCol)}'
@@ -80,12 +108,58 @@ class Pattern (m:String, tileType: String, rows: Int, cols: Int,
     m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createNode(row, col))).toArray.mkString("") +
     m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createTwoIn(row, col))).toArray.mkString("")
   }
+}
+class ClonedPattern (m:String, tileType: String, rows: Int, cols: Int,
+               groupId: String = "GFP1", offsetX: Int = 80, offsetY: Int = 120)
+  extends Pattern(m, tileType, rows, cols, groupId, offsetX, offsetY) {
 
-  private def toX(col: Int): Int = col * 10 + offsetX
-  private def toY(row: Int): Int = row * 10 + offsetY
-  private def toNodeId(row: Int, col: Int): String = s"${groupId}r${row}c$col"
-  private def toColor(row: Int, col: Int): String = {
-    val (r,c) = tt.toOriginal(row, col, rows, cols)
-    f"00${c * (256/cols)}%02X${r * (256/rows)}%02X"
+  val relative = toRelSrcNodes(matrix = m, dimensions = hXw).get // TODO repeating a previous action
+  def createDiagram(m: M): String = clones + original(relative)
+
+  private def clones: String = {
+    val brickOffset = if (tileType == "bricks") cols * 5 else 0
+    def cloneRows(row1: Int): String = {
+      val row2 = row1 + rows * 10 // TODO refactor into TileType
+      List.range(start = -(if (tileType == "bricks")brickOffset else 10*cols), end = 250, step = cols * 10).
+        map(w => {
+          clone(w, row1) + clone(w - brickOffset, row2)
+        }).mkString("")
+    }
+    val cloneAtOriginal = clone(0, 0)
+    List.range(start = -rows * 10, end = 200, step = rows * 20)
+      .map(h => cloneRows(h)).mkString("")
+      .replace(cloneAtOriginal, cloneAtOriginal.replace("#000", "#008"))
+  }
+
+  private def clone(i: Int, j: Int): String =
+    s"\t<use transform='translate($i,$j)' xlink:href='#$groupId' ${"style='stroke:#000;fill:none'"}/>\n"
+
+  private def original(m: M): String =
+    m.indices.flatMap(row =>
+      m(row).indices.flatMap(col =>
+        createNode((row, col), m(row)(col))
+      )
+    ).mkString("")
+
+  private def createNode(target: (Int, Int), n: SrcNodes): String =
+    if (n.length < 2) ""
+    else {
+      createLink(target, n(0)) + createLink(target, n(1))
+    }
+
+  private def createLink(target: (Int, Int), source: (Int, Int)): String = {
+    val (targetRow, targetCol) = target
+    val (dRow, dCol) = source
+    val sourceRow = (targetRow + dRow + rows) % rows
+    val sourceCol = // TODO refactor into TileType
+      if (tileType == "bricks" && targetRow == 0 && dRow != 0)
+        (targetCol + dCol + cols/2) % cols
+      else (targetCol + dCol + cols) % cols
+    val tag = s"${s"${toNodeId(sourceCol, sourceRow)}"}-${toNodeId(targetCol, targetRow)}"
+    val targetNode = s"${offsetX + (targetCol * 10)},${offsetY + (targetRow * 10)}"
+    val sourceNode = s"${offsetX + (dCol + targetCol) * 10},${offsetY + (dRow + targetRow) * 10}"
+    val pathData = s"M $sourceNode $targetNode"
+    s"\t\t<path d='$pathData'><title>$tag</title></path>\n"
   }
 }
+

--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -15,95 +15,108 @@
 */
 package dibl
 
-import dibl.Matrix.{toAbsWithMargins, toRelSrcNodes}
+import dibl.Matrix.{countLinks, toAbsWithMargins, toRelSrcNodes}
 
-case class Pattern(tileMatrix: String,
-                   tileType: String,
-                   groupId: String,
-                   offsetX: Int = 80,
-                   offsetY: Int = 120) {
-  require(offsetX > 0 && offsetY > 0, "invalid patch dimensions")
+object Pattern {
+  def apply(tileMatrix: String,
+            tileType: String,
+            groupId: String,
+            offsetX: Int = 80,
+            offsetY: Int = 120): String = {
+    require(offsetX > 0 && offsetY > 0, "invalid patch dimensions")
 
-  private val tt = TileType(tileType)
-  private val lines = Matrix.toMatrixLines(tileMatrix).get
-  private val tileRows = lines.length
-  private val tileCols = lines(0).length
-  private val hXw = s"${tileRows}x$tileCols"
-  val options = Array(s"matrix=${lines.mkString("%0D")}", s"tiles=$tileType")
-  val url = "https://d-bl.github.io/GroundForge/index.html"
-  private val triedM = for {
-    relative <- toRelSrcNodes(matrix = lines.mkString(""), dimensions = hXw)
-    absolute <- toAbsWithMargins(relative, tileRows, tileCols)
-  } yield absolute
+    val tt = TileType(tileType)
+    val lines = Matrix.toMatrixLines(tileMatrix).get
+    val tileRows = lines.length
+    val tileCols = lines(0).length
+    val hXw = s"${tileRows}x$tileCols"
+    val options = Array(s"matrix=${lines.mkString("%0D")}", s"tiles=$tileType")
+    val url = "https://d-bl.github.io/GroundForge/index.html"
 
-  def patch : String = triedM.map { m => s"""
-    |  <text style='font-family:Arial;font-size:11pt'>
-    |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType; $hXw; ${lines.mkString(",")}</tspan>
-    |   <tspan x='${offsetX + 15}' y='${offsetY - 0}' style='fill:#008;'>
-    |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
-    |   </tspan>
-    |  </text>
-    |  <g id ="$groupId">
-    |${createDiagram(m)}
-    |  </g>
-    |  <g>
-    |$clones
-    |  </g>
-    |""".stripMargin
-  }.getOrElse("whoops") // TODO improve error message
+    def createPatch(m: M) =  s"""
+      |  <text style='font-family:Arial;font-size:11pt'>
+      |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType; $hXw; ${lines.mkString(",")}</tspan>
+      |   <tspan x='${offsetX + 15}' y='${offsetY - 0}' style='fill:#008;'>
+      |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
+      |   </tspan>
+      |  </text>
+      |  <g id ="$groupId">
+      |${createDiagram(m)}
+      |  </g>
+      |  <g>
+      |$clones
+      |  </g>
+      |""".stripMargin
 
-  def createDiagram(m: M) = {
-    def createTwoIn(targetRow: Int, targetCol: Int): String =
-      m(targetRow)(targetCol).map { sourceNode =>
-        val (sourceRow, sourceCol) = sourceNode
-        s"""    <path
-           |      style='stroke:#000;fill:none'
-           |      d='M ${toX(sourceCol)},${toY(sourceRow)} ${toX (targetCol)},${toY(targetRow)}'
-           |    />
-           |""".stripMargin + (
-          if (m(sourceRow)(sourceCol).nonEmpty) ""
-          else createNode(sourceRow, sourceCol))
-      }.mkString("")
-    m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createTwoIn(row, col))).toArray.mkString("") +
-    m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createNode(row, col))).toArray.mkString("")
-  }
-
-  private def toX(col: Int): Int = col * 10 + offsetX
-  private def toY(row: Int): Int = row * 10 + offsetY
-  private def toColor(row: Int, col: Int): String = {
-    val (r,c) = tt.toTileIndices(row, col, tileRows, tileCols)
-    val n = tileRows * tileCols + 0f
-    val i = ((r * tileCols) + c) % n
-    val hue = i / n
-    val brightness = 0.2f + 0.15f * (i %3)
-    hslToRgb(hue, 1f, brightness)  }
-
-  def createNode(row: Int, col: Int) =
-     s"""    <path
-        |      d='m ${toX(col) + 2},${toY(row)} a 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 2,2 0 0 1 2,2 z'
-        |      style='fill:#${toColor(row, col)};stroke:none'
-        |    />
-        |""".stripMargin
-
-  private def clones: String = {
-    val brickOffset = if (tileType == "bricks") tileCols * 5 else 0
-    def cloneRows(row1: Int): String = {
-      val row2 = row1 + tileRows * 10 // TODO refactor into TileType
-      List.range(start = -(if (tileType == "bricks")brickOffset else 10*tileCols), end = 200, step = tileCols * 10).
-        map(w => {
-          clone(w, row1) + clone(w - brickOffset, row2)
-        }).mkString("")
+    def createDiagram(m: M) = {
+      def createTwoIn(targetRow: Int, targetCol: Int): String =
+        m(targetRow)(targetCol).map { sourceNode =>
+          val (sourceRow, sourceCol) = sourceNode
+          s"""    <path
+             |      style='stroke:#000;fill:none'
+             |      d='M ${toX(sourceCol)},${toY(sourceRow)} ${toX (targetCol)},${toY(targetRow)}'
+             |    />
+             |""".stripMargin + (
+            if (m(sourceRow)(sourceCol).nonEmpty) ""
+            else createNode(sourceRow, sourceCol))
+        }.mkString("")
+      m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createTwoIn(row, col))).toArray.mkString("") +
+      m.indices.flatMap(row => m(row).indices.filter(m(row)(_).nonEmpty).flatMap(col => createNode(row, col))).toArray.mkString("")
     }
-    List.range(start = -tileRows * 10, end = 200, step = tileRows * 20)
-      .map(h => cloneRows(h)).mkString("")
-  }
 
-  private def clone(i: Int, j: Int): String =
-    s"""    <use
-       |      transform='translate(${i+100},${j+40})'
-       |      xlink:href='#$groupId'
-       |      style='stroke:#000;fill:none'
-       |    />
-       |""".stripMargin
+    def toX(col: Int): Int = col * 10 + offsetX
+    def toY(row: Int): Int = row * 10 + offsetY
+    def toColor(row: Int, col: Int): String = {
+      val (r,c) = tt.toTileIndices(row, col, tileRows, tileCols)
+      val n = tileRows * tileCols + 0f
+      val i = ((r * tileCols) + c) % n
+      val hue = i / n
+      val brightness = 0.2f + 0.15f * (i %3)
+      hslToRgb(hue, 1f, brightness)  }
+
+    def createNode(row: Int, col: Int) =
+       s"""    <path
+          |      d='m ${toX(col) + 2},${toY(row)} a 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 2,2 0 0 1 2,2 z'
+          |      style='fill:#${toColor(row, col)};stroke:none'
+          |    />
+          |""".stripMargin
+
+    def clones: String = {
+      val brickOffset = if (tileType == "bricks") tileCols * 5 else 0
+      def cloneRows(row1: Int): String = {
+        val row2 = row1 + tileRows * 10 // TODO refactor into TileType
+        List.range(start = -(if (tileType == "bricks")brickOffset else 10*tileCols), end = 200, step = tileCols * 10).
+          map(w => {
+            clone(w, row1) + clone(w - brickOffset, row2)
+          }).mkString("")
+      }
+      List.range(start = -tileRows * 10, end = 200, step = tileRows * 20)
+        .map(h => cloneRows(h)).mkString("")
+    }
+
+    def clone(i: Int, j: Int): String =
+      s"""    <use
+         |      transform='translate(${i+100},${j+40})'
+         |      xlink:href='#$groupId'
+         |      style='stroke:#000;fill:none'
+         |    />
+         |""".stripMargin
+
+    def stripMargins(m: M) = countLinks(m).slice(2, 2 + tileRows).map(_.slice(2, 2 + tileCols))
+    def toNeedColor(c: Int): String = if (c % 4 == 0) "#000" else "#888"
+
+    val triedSVG = for {
+      relative <- toRelSrcNodes(matrix = lines.mkString(""), dimensions = hXw)
+      m <- toAbsWithMargins(relative, tileRows, tileCols)
+      c = stripMargins(m)
+      //_ = println(c.toList.toArray.deep.mkString("\n") + "\n")
+      colors = c.indices.map(row => c(row).indices.map(col => toNeedColor(c(row)(col))))
+      //_ = println(x.toList.toArray.deep.mkString("\n") + "\n-------------")
+      svg = createPatch(m)
+    } yield svg
+
+    triedSVG.getOrElse("<text><tspan>whoops</tspan></text>") // TODO improve error message
+  }
 }
+
 

--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -51,7 +51,7 @@ abstract class Pattern (m:String,
     val url = "https://d-bl.github.io/GroundForge/index.html"
     s"""<g>
        |  <text style='font-family:Arial;font-size:11pt'>
-       |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType, $hXw, $m</tspan>
+       |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType; $hXw; ${lines.mkString(",")}</tspan>
        |   <tspan x='${offsetX + 15}' y='${offsetY - 0}' style='fill:#008;'>
        |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
        |   </tspan>

--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -109,7 +109,7 @@ object Pattern {
 
     def clone(i: Int, j: Int): String =
       s"""    <use
-         |      transform='translate(${i+100},${j+40})'
+         |      transform='translate(${i+95},${j+45})'
          |      xlink:href='#$groupId'
          |      style='stroke:#000;fill:none'
          |    />
@@ -120,8 +120,8 @@ object Pattern {
     def createPatch(relative: M, absolute: M) =
       s"""
          |  <text style='font-family:Arial;font-size:11pt'>
-         |   <tspan x='${offsetX + 15}' y='${offsetY - 20}'>$tileType; ${tileRows}x$tileCols; ${lines.mkString(",")}</tspan>
-         |   <tspan x='${offsetX + 15}' y='${offsetY - 0}' style='fill:#008;'>
+         |   <tspan x='${offsetX - 15}' y='${offsetY - 50}'>$tileType; ${tileRows}x$tileCols; ${lines.mkString(",")}</tspan>
+         |   <tspan x='${offsetX - 15}' y='${offsetY - 30}' style='fill:#008;'>
          |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
          |   </tspan>
          |  </text>

--- a/src/main/scala/dibl/Pattern.scala
+++ b/src/main/scala/dibl/Pattern.scala
@@ -15,7 +15,7 @@
 */
 package dibl
 
-import dibl.Matrix.{countLinks, toAbsWithMargins, toRelSrcNodes}
+import dibl.Matrix.{countLinks, toAbsWithMargins, toMatrixLines, toRelSrcNodes}
 
 import scala.collection.immutable.IndexedSeq
 import scala.util.Try
@@ -31,113 +31,124 @@ object Pattern {
             offsetX: Int = 80,
             offsetY: Int = 120
            ): String = {
-    val lines = {
-      val triedLines = Matrix.toMatrixLines(tileMatrix)
-      if (triedLines.isFailure) return failureMessage(triedLines)
-      triedLines.get
-    }
-    val tt = TileType(tileType)
-    val tileRows = lines.length
-    val tileCols = lines(0).length
-    def toX(col: Int): Int = col * 10 + offsetX
-    def toY(row: Int): Int = row * 10 + offsetY
-    def stripMargins(m: M) = countLinks(m).slice(2, 2 + tileRows).map(_.slice(2, 2 + tileCols))
-
-    def createDiagram(relative: M, absolute: M) = {
-
-      val needColor: Seq[(Int, Int)] = {
-        val m = stripMargins(absolute)
-        m.indices.flatMap(row => m(row).indices.map(col => (row, col))).
-          filter(t => m(t._1)(t._2) % 4 > 0)
-      }
-
-      def toColor(row: Int, col: Int): String = {
-        val cell = tt.toTileIndices(row, col, tileRows, tileCols)
-        val i = needColor.indexOf(cell) + 0f
-        if (i < 0) "999999" else {
-          val hue = i / needColor.size
-          val brightness = 0.2f + 0.15f * (i % 3)
-          hslToRgb(hue, 1f, brightness)
-        }
-      }
-
-      def createNode(row: Int, col: Int) =
-        s"""    <path
-           |      d='m ${toX(col) + 2},${toY(row)} a 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 2,2 0 0 1 2,2 z'
-           |      style='fill:#${toColor(row, col)};fill-opacity:0.85;stroke:none'
-           |    />
-           |""".stripMargin
-
-      def createTwoIn(targetRow: Int, targetCol: Int): String =
-        relative(targetRow)(targetCol).map { sourceNode =>
-          val (r, c) = sourceNode
-          val sourceRow = r + targetRow
-          val sourceCol = c + targetCol
-          s"""    <path
-             |      style='stroke:#000;fill:none'
-             |      d='M ${toX(sourceCol)},${toY(sourceRow)} ${toX(targetCol)},${toY(targetRow)}'
-             |    />
-             |""".stripMargin + (
-            if (absolute(sourceRow+2)(sourceCol+2).nonEmpty) ""
-            else createNode(sourceRow, sourceCol))
-        }.mkString("")
-
-      def forAllCells(createSvgObject: (Int, Int) => String): IndexedSeq[Char] =
-        relative.indices.
-          flatMap(row => relative(row).indices.
-            filter(col => relative(row)(col).nonEmpty).
-            flatMap(col => createSvgObject(row, col))
-          )
-
-      (forAllCells(createTwoIn) ++
-        forAllCells(createNode)
-        ).toArray.mkString("")
-    }
-
-    def clones: String = {
-      val brickOffset = if (tileType == "bricks") tileCols * 5 else 0
-      def cloneRows(row1: Int): String = {
-        val row2 = row1 + tileRows * 10 // TODO refactor into TileType
-        List.range(start = -(if (tileType == "bricks")brickOffset else 10*tileCols), end = 200, step = tileCols * 10).
-          map(w => {
-            clone(w, row1) + clone(w - brickOffset, row2)
-          }).mkString("")
-      }
-      List.range(start = -tileRows * 10, end = 200, step = tileRows * 20)
-        .map(h => cloneRows(h)).mkString("")
-    }
-
-    def clone(i: Int, j: Int): String =
-      s"""    <use
-         |      transform='translate(${i+95},${j+45})'
-         |      xlink:href='#$groupId'
-         |      style='stroke:#000;fill:none'
-         |    />
-         |""".stripMargin
-
-    val options = Array(s"matrix=${lines.mkString("%0D")}", s"tiles=$tileType")
-    val url = "https://d-bl.github.io/GroundForge/index.html"
-    def createPatch(relative: M, absolute: M) =
-      s"""
-         |  <text style='font-family:Arial;font-size:11pt'>
-         |   <tspan x='${offsetX - 15}' y='${offsetY - 50}'>$tileType; ${tileRows}x$tileCols; ${lines.mkString(",")}</tspan>
-         |   <tspan x='${offsetX - 15}' y='${offsetY - 30}' style='fill:#008;'>
-         |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
-         |   </tspan>
-         |  </text>
-         |  <g id ="$groupId">
-         |${createDiagram(relative, absolute)}
-         |  </g>
-         |  <g>
-         |$clones
-         |  </g>
-         |""".stripMargin
 
     val triedSVG = for {
+      lines <- toMatrixLines(tileMatrix)
       relative <- toRelSrcNodes(tileMatrix)
-      absolute <- toAbsWithMargins(relative, tileRows, tileCols)
-    } yield createPatch(relative,absolute)
+      rows = lines.length
+      cols = lines(0).length
+      absolute <- toAbsWithMargins(relative, rows, cols)
+    } yield new Pattern(
+      tileMatrix,
+      tileType,
+      groupId,
+      offsetX,
+      offsetY,
+      lines,
+      relative,
+      absolute
+    ).createPatch
 
     triedSVG.getOrElse(failureMessage(triedSVG))
   }
+}
+
+private class Pattern (tileMatrix: String,
+                       tileType: String,
+                       groupId: String = "GF0",
+                       offsetX: Int = 80,
+                       offsetY: Int = 120,
+                       lines: Array[String],
+                       relative: M,
+                       absolute: M
+                      ){
+  val tt = TileType(tileType)
+  val tileRows = lines.length
+  val tileCols = lines(0).length
+  def toX(col: Int): Int = col * 10 + offsetX
+  def toY(row: Int): Int = row * 10 + offsetY
+  def stripMargins(m: M) = countLinks(m).slice(2, 2 + tileRows).map(_.slice(2, 2 + tileCols))
+
+  val needColor: Seq[(Int, Int)] = {
+    val m = stripMargins(absolute)
+    m.indices.flatMap(row => m(row).indices.map(col => (row, col))).
+      filter(t => m(t._1)(t._2) % 4 > 0)
+  }
+
+  def toColor(row: Int, col: Int): String = {
+    val cell = tt.toTileIndices(row, col, tileRows, tileCols)
+    val i = needColor.indexOf(cell) + 0f
+    if (i < 0) "999999" else {
+      val hue = i / needColor.size
+      val brightness = 0.2f + 0.15f * (i % 3)
+      hslToRgb(hue, 1f, brightness)
+    }
+  }
+
+  def createNode(row: Int, col: Int) =
+    s"""    <path
+        |      d='m ${toX(col) + 2},${toY(row)} a 2,2 0 0 1 -2,2 2,2 0 0 1 -2,-2 2,2 0 0 1 2,-2 2,2 0 0 1 2,2 z'
+        |      style='fill:#${toColor(row, col)};fill-opacity:0.85;stroke:none'
+        |    />
+        |""".stripMargin
+
+  def createTwoIn(targetRow: Int, targetCol: Int): String =
+    relative(targetRow)(targetCol).map { sourceNode =>
+      val (r, c) = sourceNode
+      val sourceRow = r + targetRow
+      val sourceCol = c + targetCol
+      s"""    <path
+          |      style='stroke:#000;fill:none'
+          |      d='M ${toX(sourceCol)},${toY(sourceRow)} ${toX(targetCol)},${toY(targetRow)}'
+          |    />
+          |""".stripMargin + (
+        if (absolute(sourceRow+2)(sourceCol+2).nonEmpty) ""
+        else createNode(sourceRow, sourceCol))
+    }.mkString("")
+
+  def forAllCells(createSvgObject: (Int, Int) => String): IndexedSeq[Char] =
+    relative.indices.
+      flatMap(row => relative(row).indices.
+        filter(col => relative(row)(col).nonEmpty).
+        flatMap(col => createSvgObject(row, col))
+      )
+
+  def clones: String = {
+    val brickOffset = if (tileType == "bricks") tileCols * 5 else 0
+    def cloneRows(row1: Int): String = {
+      val row2 = row1 + tileRows * 10 // TODO refactor into TileType
+      List.range(start = -(if (tileType == "bricks")brickOffset else 10*tileCols), end = 200, step = tileCols * 10).
+        map(w => {
+          clone(w, row1) + clone(w - brickOffset, row2)
+        }).mkString("")
+    }
+    List.range(start = -tileRows * 10, end = 200, step = tileRows * 20)
+      .map(h => cloneRows(h)).mkString("")
+  }
+
+  def clone(i: Int, j: Int): String =
+    s"""    <use
+        |      transform='translate(${i+95},${j+45})'
+        |      xlink:href='#$groupId'
+        |      style='stroke:#000;fill:none'
+        |    />
+        |""".stripMargin
+
+  val options = Array(s"matrix=${lines.mkString("%0D")}", s"tiles=$tileType")
+  val url = "https://d-bl.github.io/GroundForge/index.html"
+  def createPatch =
+    s"""
+       |  <text style='font-family:Arial;font-size:11pt'>
+       |   <tspan x='${offsetX - 15}' y='${offsetY - 50}'>$tileType; ${tileRows}x$tileCols; ${lines.mkString(",")}</tspan>
+       |   <tspan x='${offsetX - 15}' y='${offsetY - 30}' style='fill:#008;'>
+       |    <a xlink:href='$url?${options.mkString("&amp;")}'>pair/thread diagrams</a>
+       |   </tspan>
+       |  </text>
+       |  <g id ="$groupId">
+       |${(forAllCells(createTwoIn) ++ forAllCells(createNode)).toArray.mkString("")}
+       |  </g>
+       |  <g>
+       |$clones
+       |  </g>
+       |""".stripMargin
 }

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -9,7 +9,7 @@ import scala.scalajs.js.annotation.JSExport
 @JSExport
 case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' width='210mm'") {
   private val nameSpaces = "xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape'"
-  private val patterns = new ListBuffer[Pattern]
+  private val patterns = new ListBuffer[String]
 
   @JSExport
   def add(m: String, tileType: String): PatternSheet = {
@@ -27,6 +27,6 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
        |$toSvgGroups
        |</svg>
        |""".stripMargin
-  def toList: List[Pattern] = patterns.toList
-  def toSvgGroups: String = patterns.map(_.patch).mkString("")
+  def toList: List[String] = patterns.toList
+  def toSvgGroups: String = patterns.mkString("")
 }

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -28,5 +28,5 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
        |</svg>
        |""".stripMargin
   def toList: List[Pattern] = patterns.toList
-  def toSvgGroups: String = patterns.map(_.patch()).mkString("")
+  def toSvgGroups: String = patterns.map(_.patch).mkString("")
 }

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -17,7 +17,7 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
     val x = 70 + (n / patchRows) * 360
     val y = 90 + (n % patchRows) * 335
     val lines = Matrix.toMatrixLines(m).get
-    patterns.append(new Pattern(lines.mkString(""), tileType, lines.length, lines(0).length, s"GFP$n", x, y))
+    patterns.append(ConnectedPattern(lines.mkString(""), tileType, lines.length, lines(0).length, s"GFP$n", x, y))
     this
   }
 

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -7,15 +7,15 @@ import scala.scalajs.js.annotation.JSExport
   * @param pageSize default A4, in fact attributes for the SVG root element
   */
 @JSExport
-case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' width='210mm'") {
+case class PatternSheet(patchRows: Int = 2, pageSize: String = "height='210mm' width='297mm'") {
   private val nameSpaces = "xmlns:xlink='http://www.w3.org/1999/xlink' xmlns='http://www.w3.org/2000/svg' xmlns:inkscape='http://www.inkscape.org/namespaces/inkscape'"
   private val patterns = new ListBuffer[String]
 
   @JSExport
   def add(m: String, tileType: String): PatternSheet = {
     val n = patterns.size
-    val x = 70 + (n / patchRows) * 360
-    val y = 90 + (n % patchRows) * 335
+    val x = 25 + (n / patchRows) * 360
+    val y = 95 + (n % patchRows) * 335
     patterns.append(Pattern(m, tileType, s"GFP$n", x, y))
     this
   }

--- a/src/main/scala/dibl/PatternSheet.scala
+++ b/src/main/scala/dibl/PatternSheet.scala
@@ -16,14 +16,17 @@ case class PatternSheet(patchRows: Int = 3, pageSize: String = "height='297mm' w
     val n = patterns.size
     val x = 70 + (n / patchRows) * 360
     val y = 90 + (n % patchRows) * 335
-    val lines = Matrix.toMatrixLines(m).get
-    patterns.append(ConnectedPattern(lines.mkString(""), tileType, lines.length, lines(0).length, s"GFP$n", x, y))
+    patterns.append(Pattern(m, tileType, s"GFP$n", x, y))
     this
   }
 
   //noinspection AccessorLikeMethodIsEmptyParen
   @JSExport // parentheses are required for JavaScript
-  def toSvgDoc():String = s"${s"<svg version='1.1' id='svg2' $pageSize $nameSpaces>"}\n$toSvgGroups\n</svg>"
+  def toSvgDoc():String = s"""
+       |<svg version='1.1' id='svg2' $pageSize $nameSpaces>
+       |$toSvgGroups
+       |</svg>
+       |""".stripMargin
   def toList: List[Pattern] = patterns.toList
   def toSvgGroups: String = patterns.map(_.patch()).mkString("")
 }

--- a/src/main/scala/dibl/TileType.scala
+++ b/src/main/scala/dibl/TileType.scala
@@ -23,11 +23,11 @@ abstract class TileType {
 
   /** @param row row number in the generated patch
     * @param col col number in the generated patch
-    * @param rows height of the matrix that defines the pattern
-    * @param cols width of the matrix that defines the pattern
+    * @param rows height of the tile matrix that defines the pattern
+    * @param cols width of the tile matrix that defines the pattern
     * @return reduced values for (row,col)
     */
-  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int)
+  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int)
 }
 
 object TileType {
@@ -45,7 +45,7 @@ object Checker extends TileType {
 
   def toChecker(m: M): M = m
 
-  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
+  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
     val c = col % cols
     val r = row % rows
     (r,c)
@@ -61,7 +61,7 @@ object Brick extends TileType {
       }
     }
 
-  def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
+  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
     val offset = ((row + rows) / rows % 2) * (cols / 2)
     val c = (col + cols + offset) % cols
     val r = row % rows

--- a/src/main/scala/dibl/TileType.scala
+++ b/src/main/scala/dibl/TileType.scala
@@ -62,8 +62,8 @@ object Brick extends TileType {
     }
 
   def toOriginal(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
-    val offset = (row / rows % 2) * (cols / 2)
-    val c = (col + offset) % cols
+    val offset = ((row + rows) / rows % 2) * (cols / 2)
+    val c = (col + cols + offset) % cols
     val r = row % rows
     (r,c)
   }

--- a/src/main/scala/dibl/TileType.scala
+++ b/src/main/scala/dibl/TileType.scala
@@ -21,13 +21,13 @@ abstract class TileType {
 
   def toChecker(m: M): M
 
-  /** @param row row number in the generated patch
-    * @param col col number in the generated patch
-    * @param rows height of the tile matrix that defines the pattern
-    * @param cols width of the tile matrix that defines the pattern
+  /** @param row relative row number in the generated patch
+    * @param col relative col number in the generated patch
+    * @param tileRows height of the tile matrix that defines the pattern
+    * @param tileCols width of the tile matrix that defines the pattern
     * @return reduced values for (row,col)
     */
-  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int)
+  def toAbsTileIndices(row: Int, col: Int, tileRows: Int, tileCols: Int): (Int, Int)
 }
 
 object TileType {
@@ -45,14 +45,8 @@ object Checker extends TileType {
 
   def toChecker(m: M): M = m
 
-  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
-    // correct for the margin but keep positive
-    val rowI = row - 2 + rows
-    val colI = col - 2 + cols
-
-    val c = colI % cols
-    val r = rowI % rows
-    (r,c)
+  def toAbsTileIndices(row: Int, col: Int, tileRows: Int, tileCols: Int): (Int, Int) = {
+    ((row + tileRows) % tileRows, (col + tileCols) % tileCols)
   }
 }
 
@@ -65,15 +59,9 @@ object Brick extends TileType {
       }
     }
 
-  def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
-    // correct for the margin but keep positive
-    val rowI = row - 2 + rows
-    val colI = col - 2 + cols
-
-    val offset = ((rowI + rows) / rows % 2) * (cols / 2)
-    val c = (colI + cols + offset) % cols
-    val r = rowI % rows
-    (r,c)
+  def toAbsTileIndices(row: Int, col: Int, tileRows: Int, tileCols: Int): (Int, Int) = {
+    val cell@(r,c) = Checker.toAbsTileIndices(row, col, tileRows, tileCols)
+    if (row >= 0) cell else (r, (c + tileCols / 2) % tileCols )
   }
 
   /** Creates a checkerboard-matrix from a brick-matrix by

--- a/src/main/scala/dibl/TileType.scala
+++ b/src/main/scala/dibl/TileType.scala
@@ -46,8 +46,12 @@ object Checker extends TileType {
   def toChecker(m: M): M = m
 
   def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
-    val c = col % cols
-    val r = row % rows
+    // correct for the margin but keep positive
+    val rowI = row - 2 + rows
+    val colI = col - 2 + cols
+
+    val c = colI % cols
+    val r = rowI % rows
     (r,c)
   }
 }
@@ -62,9 +66,13 @@ object Brick extends TileType {
     }
 
   def toTileIndices(row: Int, col: Int, rows: Int, cols: Int): (Int, Int) = {
-    val offset = ((row + rows) / rows % 2) * (cols / 2)
-    val c = (col + cols + offset) % cols
-    val r = row % rows
+    // correct for the margin but keep positive
+    val rowI = row - 2 + rows
+    val colI = col - 2 + cols
+
+    val offset = ((rowI + rows) / rows % 2) * (cols / 2)
+    val c = (colI + cols + offset) % cols
+    val r = rowI % rows
     (r,c)
   }
 

--- a/src/main/scala/dibl/package.scala
+++ b/src/main/scala/dibl/package.scala
@@ -85,4 +85,41 @@ package object dibl {
           "target" -> nodes.tail.head,
           "border" -> true
       ))
+
+  /**
+    * Converts an HSL color value to RGB. Conversion formula
+    * adapted from http://en.wikipedia.org/wiki/HSL_color_space.
+    * Assumes h, s, and l are contained in the set [0, 1] and
+    * returns r, g, and b in the set [0, 255].
+    *
+    * from https://gist.github.com/mjackson/5311256
+    *
+    * @param h The hue
+    * @param s The saturation
+    * @param l The lightness
+    * @return The Hexadecimal RGB representation
+    */
+  def hslToRgb(h: Float, s: Float, l: Float): String = {
+
+    val (r, g, b) =
+    if (s == 0) (1,1,1) /* achromatic */ else {
+      def hue2rgb(p: Float, q: Float, t: Float): Float = {
+        var tt = t
+        if (tt < 0f) tt += 1f
+        if (tt > 1f) tt -= 1f
+        if (tt < 1f/6f) return p + (q - p) * 6f * tt
+        if (tt < 1f/2f) return q
+        if (tt < 2f/3f) return p + (q - p) * (2f/3f - tt) * 6f
+        p
+      }
+      val q = if (l < 0.5f)  l * (1f + s) else l + s - l * s
+      val p = 2f * l - q
+
+      ( (255 * hue2rgb(p, q, h + 1f/3f)).toInt
+      , (255 * hue2rgb(p, q, h)).toInt
+      , (255 * hue2rgb(p, q, h - 1f/3f)).toInt
+      )
+    }
+    f"$r%02X$g%02X$b%02X"
+  }
 }

--- a/src/test/scala/dibl/PatternSpec.scala
+++ b/src/test/scala/dibl/PatternSpec.scala
@@ -33,11 +33,16 @@ class PatternSpec extends FlatSpec with Matchers {
 
   "pattern sheet" should "succeed" in {
     val patterns = new PatternSheet
-    patterns.add("586- -4-5 5-21 -5-7" ,"bricks")
     patterns.add("586- -4-5 5-21 -5-7", "bricks")
     patterns.add("4831 -117 5-7- 86-5", "checker")
     patterns.add("4832 2483", "bricks")
     patterns.add("588- -4-5 6-58 -214", "checker")
+    patterns.add("-4-5 6-58 -214 588-", "checker")
+    patterns.add("5831 -4-7" ,"bricks")
+    //            -5---5-5 5-O-E-5-
+    patterns.add("-5---5-5 5-O-E-5-", "bricks") // double length horizontal lines
+    patterns.add("5---5-5- -O-E-5-5", "bricks") // double length horizontal lines
+    patterns.add("586- -4-5 5-21 -5-777", "checker") // reports an error
     FileUtils.write(new File(s"target/patterns/pattern-sheet.svg"), patterns.toSvgDoc())
   }
 

--- a/src/test/scala/dibl/PatternSpec.scala
+++ b/src/test/scala/dibl/PatternSpec.scala
@@ -34,15 +34,17 @@ class PatternSpec extends FlatSpec with Matchers {
   "pattern sheet" should "succeed" in {
     val patterns = new PatternSheet
     patterns.add("B-5-C- -5-5-- B---C-", "bricks") // double length vertical rows
+    patterns.add("-5---5-5 5-O-E-5-", "bricks") // double length horizontal lines
+
     patterns.add("586- -4-5 5-21 -5-7", "bricks")
     patterns.add("4831 -117 5-7- 86-5", "checker")
 
-    patterns.add("-5---5-5 5-O-E-5-", "bricks") // double length horizontal lines
     patterns.add("588- -4-5 6-58 -214", "checker")
     patterns.add("5831 -4-7" ,"bricks")
 
     patterns.add("4832 2483", "bricks")
     patterns.add("5---5-5- -O-E-5-5", "bricks") // double length horizontal lines
+
     patterns.add("586- -4-5 5-21 -5-777", "checker") // reports an error
     FileUtils.write(new File(s"target/patterns/pattern-sheet.svg"), patterns.toSvgDoc())
   }

--- a/src/test/scala/dibl/PatternSpec.scala
+++ b/src/test/scala/dibl/PatternSpec.scala
@@ -69,7 +69,7 @@ class PatternSpec extends FlatSpec with Matchers {
   }
 
   "minimal" should "succeed" in {
-    val patterns = new PatternSheet(1, "width='340' height='330'")
+    val patterns = PatternSheet(1, "width='340' height='330'")
     patterns.add("586- -4-5 5-21 -5-7","bricks")
     FileUtils.write(new File(s"target/patterns/minimal.svg"), patterns.toSvgDoc())
   }

--- a/src/test/scala/dibl/PatternSpec.scala
+++ b/src/test/scala/dibl/PatternSpec.scala
@@ -33,14 +33,15 @@ class PatternSpec extends FlatSpec with Matchers {
 
   "pattern sheet" should "succeed" in {
     val patterns = new PatternSheet
+    patterns.add("B-5-C- -5-5-- B---C-", "bricks") // double length vertical rows
     patterns.add("586- -4-5 5-21 -5-7", "bricks")
     patterns.add("4831 -117 5-7- 86-5", "checker")
-    patterns.add("4832 2483", "bricks")
-    patterns.add("588- -4-5 6-58 -214", "checker")
-    patterns.add("-4-5 6-58 -214 588-", "checker")
-    patterns.add("5831 -4-7" ,"bricks")
-    //            -5---5-5 5-O-E-5-
+
     patterns.add("-5---5-5 5-O-E-5-", "bricks") // double length horizontal lines
+    patterns.add("588- -4-5 6-58 -214", "checker")
+    patterns.add("5831 -4-7" ,"bricks")
+
+    patterns.add("4832 2483", "bricks")
     patterns.add("5---5-5- -O-E-5-5", "bricks") // double length horizontal lines
     patterns.add("586- -4-5 5-21 -5-777", "checker") // reports an error
     FileUtils.write(new File(s"target/patterns/pattern-sheet.svg"), patterns.toSvgDoc())


### PR DESCRIPTION
After all connectors were bound to InkScape with a buggy implementation. With coloured dots instructions are even easier for clones. More over: the tile next to each patch looks a bit like the [legend] for the advanced options of the web page. The dots replace the digits, identical coloured dots should move together.

[legend]: https://github.com/d-bl/GroundForge/blob/46e04ee/images/legend.png