### PR TITLE
twistmarks for start- and endtwists with colorcode element

### DIFF
--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -365,7 +365,7 @@ const GF_Random = {
                     </marker>`
             }
 
-            // copied from GF_sttches.setcolorcode()
+            // copied from GF_stitches.setcolorcode()
             colorCodeSvg = document.createElement("colorCodeSvg");
 
             // the middle of the base-path has to be at least 10 units of the centre, else to close to colourcode-block

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -337,10 +337,14 @@ const GF_Random = {
             colorCodeSvg = document.createElement("colorCodeSvg");
             twistMarkSvg = document.createElement("twistMarkSvg");
 
-            southEast = "3";
-            southWest = "2";
-            northEast = "1";
-            northWest = "2";
+            southEast = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("L","")).length.toString();
+            southWest = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("R","")).length.toString();
+            northEast = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("L","")).length.toString();
+            northWest = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("R","")).length.toString();
+            if (southEast > 3) {southEast = 3};
+            if (southWest > 3) {southWest = 3};
+            if (northEast > 3) {northEast = 3};
+            if (northWest > 3) {northWest = 3};
 
             // line not long enough for more than 3 twistmarks
             twistMarkSvg.innerHTML = `
@@ -362,6 +366,7 @@ const GF_Random = {
                 <path d="M 22 22 L 31 13 M 31 13 L 40 4" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${northEast}');"></path>
                 </svg>`;
 
+            // todo : place colorCodeSvg on top of twistMarkSvg. Playing with translate seems to cut of edges on the overlap.
             colorCodeSvg.innerHTML = `<svg width="20px" height="25px">0
             <g transform="scale(2,2)">
             <g transform="translate(5,6)">

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -334,8 +334,21 @@ const GF_Random = {
 
             // copied from GF_stitches.setcolorcode()
             colorCodeSvg = document.createElement("colorCodeSvg");
-            colorCodeSvg.innerHTML = `
-            <svg width="20px" height="25px">
+
+            colorCodeSvg.innerHTML += `
+                <svg width="40px" height="40px">
+                <defs>
+                    <marker id="twist-1" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
+                    <path d="M 0 6 L 0 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
+                    </marker>
+                    <marker id="twist-2" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
+                    <path d="M -1 6 L -1 -6 M 1 6 L 1,-6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
+                    </marker>
+                    <marker id="twist-3" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
+                    <path d="M -1.2 6 L -1.2 -6 M 0 6 L 0 -6 M 1.2 6 L 1.2 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
+                    </marker>
+                 </defs>
+                <path d="M 22 22 L 31 31 M 31 31 L 40 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-3');"></path>
             <g transform="scale(2,2)">
             <g transform="translate(5,6)">
               ${PairSvg.shapes(displayStitch.toLowerCase())}

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -316,7 +316,8 @@ const GF_Random = {
 
         let displayStitch;
         let displayElement;
-        let threadSvg, colorCodeSvg, figure;
+        let threadSvg, colorCodeSvg, figure, twistMarkSvg;
+        let southEast, southWest, northEast, northWest;
 
         displayElement = document.getElementById("displayRandomArray");
         displayElement.innerHTML = "";
@@ -334,9 +335,16 @@ const GF_Random = {
 
             // copied from GF_stitches.setcolorcode()
             colorCodeSvg = document.createElement("colorCodeSvg");
+            twistMarkSvg = document.createElement("twistMarkSvg");
 
-            colorCodeSvg.innerHTML += `
-                <svg width="40px" height="40px">
+            southEast = "3";
+            southWest = "2";
+            northEast = "1";
+            northWest = "2";
+
+            // line not long enough for more than 3 twistmarks
+            twistMarkSvg.innerHTML = `
+                <svg width="40px" height="40px" fill="none">
                 <defs>
                     <marker id="twist-1" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
                     <path d="M 0 6 L 0 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
@@ -348,18 +356,25 @@ const GF_Random = {
                     <path d="M -1.2 6 L -1.2 -6 M 0 6 L 0 -6 M 1.2 6 L 1.2 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
                     </marker>
                  </defs>
-                <path d="M 22 22 L 31 31 M 31 31 L 40 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-3');"></path>
+                <path d="M 22 22 L 31 31 M 31 31 L 40 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${southEast}');"></path>
+                <path d="M 22 22 L 13 31 M 13 31 L 4 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${southWest}');"></path>
+                <path d="M 22 22 L 13 13 M 13 13 L 4 4" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${northWest}');"></path>
+                <path d="M 22 22 L 31 13 M 31 13 L 40 4" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${northEast}');"></path>
+                </svg>`;
+
+            colorCodeSvg.innerHTML = `<svg width="20px" height="25px">0
             <g transform="scale(2,2)">
             <g transform="translate(5,6)">
               ${PairSvg.shapes(displayStitch.toLowerCase())}
             </g>
             </g>
-            </svg>`
+            </svg>`;
 
             figure = document.createElement("figure");
             figure.append(threadSvg);
 
             displayElement.appendChild(figure);
+            displayElement.appendChild(twistMarkSvg);
             displayElement.appendChild(colorCodeSvg);
             displayElement.innerHTML += "&nbsp;" + "&nbsp;" + displayStitch;
             displayElement.innerHTML += "<br>";

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -346,6 +346,10 @@ const GF_Random = {
             if (northEast > 3) {northEast = 3};
             if (northWest > 3) {northWest = 3};
 
+            function twistMarkerLine(path,swne) {
+                return `<path d="M 20 20 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
+            };
+
             // line not long enough for more than 3 twistmarks
             twistMarkSvg.innerHTML = `
                 <svg width="40px" height="40px" fill="none">
@@ -360,16 +364,14 @@ const GF_Random = {
                     <path d="M -1.2 6 L -1.2 -6 M 0 6 L 0 -6 M 1.2 6 L 1.2 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
                     </marker>
                  </defs>
-                <path d="M 22 22 L 31 31 M 31 31 L 40 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${southEast}');"></path>
-                <path d="M 22 22 L 13 31 M 13 31 L 4 40" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${southWest}');"></path>
-                <path d="M 22 22 L 13 13 M 13 13 L 4 4" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${northWest}');"></path>
-                <path d="M 22 22 L 31 13 M 31 13 L 40 4" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${northEast}');"></path>
-                </svg>`;
-
-            // todo : place colorCodeSvg on top of twistMarkSvg. Playing with translate seems to cut of edges on the overlap.
-            colorCodeSvg.innerHTML = `<svg width="20px" height="25px">0
+                 ${twistMarkerLine("L 30 30 M 30 30 L 40 40", southEast)}
+                 ${twistMarkerLine("L 10 30 M 10 30 L  0 40", southWest)}
+                 ${twistMarkerLine("L 10 10 M 10 10 L  0  0", northWest)}
+                 ${twistMarkerLine("L 30 10 M 30 10 L 40  0", northEast)}
+                 
+           
             <g transform="scale(2,2)">
-            <g transform="translate(5,6)">
+            <g transform="translate(10,10)">
               ${PairSvg.shapes(displayStitch.toLowerCase())}
             </g>
             </g>
@@ -419,7 +421,6 @@ const GF_Random = {
         return GF_Random.stitchArray;
     },
 }
-
 
 
 

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -333,50 +333,51 @@ const GF_Random = {
             GF_svgP2T.newStitch(displayStitch, 0,0, threadSvg,40,60);
             GF_svgP2T.addThreadClasses(threadSvg);          // this gives the lines their color
 
-           // set variabeles for twistmarks
-
+            // set variabeles for twistmarks
             southEast = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("L","")).length.toString();
             southWest = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("R","")).length.toString();
             northEast = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("L","")).length.toString();
             northWest = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("R","")).length.toString();
-            if (southEast > 4) {southEast = 4};
-            if (southWest > 4) {southWest = 4};
-            if (northEast > 4) {northEast = 4};
-            if (northWest > 4) {northWest = 4};
+            if (southEast > 5) {southEast = 5}
+            if (southWest > 5) {southWest = 5}
+            if (northEast > 5) {northEast = 5}
+            if (northWest > 5) {northWest = 5}
+
+            let t1 = "M -1.25 6 L -1.25 -6";
+            let t2 = t1 + " " + "M -0.5 6 L -0.5 -6" ;
+            let t3 = t2 + " " + "M 0.25 6 L 0.25 -6" ;
+            let t4 = t3 + " " + "M 1 6 L 1 -6" ;
+            let t5 = t4 + " " + "M 1.75 6 L 1.75 -6" ;
 
             function twistMarkerBase(path,swne) {
-                return `<path d="M 20 20 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
-            };
+                return `<path d="M 26 26 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
+            }
             function twistMarkerLine(twistId, path) {
                 return `<marker id="${twistId}" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
                     <path d="${path}" fill="#000" stroke="#000" stroke-width="0.5px"></path>
                     </marker>`
-            };
+            }
 
             // copied from GF_sttches.setcolorcode()
             colorCodeSvg = document.createElement("colorCodeSvg");
 
-            let t1 = "M -0.8 6 L -0.8 -6";
-            let t2 = t1 + " " + "M 0 6 L 0 -6" ;
-            let t3 = t2 + " " + "M 0.8 6 L 0.8 -6" ;
-            let t4 = t3 + " " + "M 1.6 6 L 1.6 -6" ;
-
-            // line not long enough for more than 3 twistmarks
+            // the middle of the base-path has to be at least 10 units of the centre, else to close to colorcode-block
             colorCodeSvg.innerHTML = `
-                <svg width="40px" height="40px" fill="none">
+                <svg width="50px" height="50px" fill="none">
                 <defs>
                    ${twistMarkerLine("twist-1",`${t1}` )}
                    ${twistMarkerLine("twist-2",`${t2}` )}
                    ${twistMarkerLine("twist-3",`${t3}` )}
                    ${twistMarkerLine("twist-4",`${t4}` )}
+                   ${twistMarkerLine("twist-5",`${t5}` )}
                 </defs>
-                ${twistMarkerBase("L 30 30 M 30 30 L 40 40", southEast)}
-                ${twistMarkerBase("L 10 30 M 10 30 L  0 40", southWest)}
-                ${twistMarkerBase("L 10 10 M 10 10 L  0  0", northWest)}
-                ${twistMarkerBase("L 30 10 M 30 10 L 40  0", northEast)}
+                ${twistMarkerBase("L 36 36 M 36 36 L 52 52", southEast)}
+                ${twistMarkerBase("L 16 36 M 16 36 L  0 52", southWest)}
+                ${twistMarkerBase("L 16 16 M 16 16 L  0  0", northWest)}
+                ${twistMarkerBase("L 36 16 M 36 16 L 52  0", northEast)}
                  
             <g transform="scale(2,2)">
-            <g transform="translate(10,10)">
+            <g transform="translate(13,13)">
               ${PairSvg.shapes(displayStitch.toLowerCase())}
             </g>
             </g>

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -316,7 +316,7 @@ const GF_Random = {
 
         let displayStitch;
         let displayElement;
-        let threadSvg, colorCodeSvg, figure, twistMarkSvg;
+        let threadSvg, colorCodeSvg, figure;
         let southEast, southWest, northEast, northWest;
 
         displayElement = document.getElementById("displayRandomArray");
@@ -333,43 +333,48 @@ const GF_Random = {
             GF_svgP2T.newStitch(displayStitch, 0,0, threadSvg,40,60);
             GF_svgP2T.addThreadClasses(threadSvg);          // this gives the lines their color
 
-            // copied from GF_stitches.setcolorcode()
-            colorCodeSvg = document.createElement("colorCodeSvg");
-            twistMarkSvg = document.createElement("twistMarkSvg");
+           // set variabeles for twistmarks
 
             southEast = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("L","")).length.toString();
             southWest = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("R","")).length.toString();
             northEast = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("L","")).length.toString();
             northWest = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("R","")).length.toString();
-            if (southEast > 3) {southEast = 3};
-            if (southWest > 3) {southWest = 3};
-            if (northEast > 3) {northEast = 3};
-            if (northWest > 3) {northWest = 3};
+            if (southEast > 4) {southEast = 4};
+            if (southWest > 4) {southWest = 4};
+            if (northEast > 4) {northEast = 4};
+            if (northWest > 4) {northWest = 4};
 
-            function twistMarkerLine(path,swne) {
+            function twistMarkerBase(path,swne) {
                 return `<path d="M 20 20 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
             };
+            function twistMarkerLine(twistId, path) {
+                return `<marker id="${twistId}" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
+                    <path d="${path}" fill="#000" stroke="#000" stroke-width="0.5px"></path>
+                    </marker>`
+            };
+
+            // copied from GF_sttches.setcolorcode()
+            colorCodeSvg = document.createElement("colorCodeSvg");
+
+            let t1 = "M -0.8 6 L -0.8 -6";
+            let t2 = t1 + " " + "M 0 6 L 0 -6" ;
+            let t3 = t2 + " " + "M 0.8 6 L 0.8 -6" ;
+            let t4 = t3 + " " + "M 1.6 6 L 1.6 -6" ;
 
             // line not long enough for more than 3 twistmarks
-            twistMarkSvg.innerHTML = `
+            colorCodeSvg.innerHTML = `
                 <svg width="40px" height="40px" fill="none">
                 <defs>
-                    <marker id="twist-1" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
-                    <path d="M 0 6 L 0 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
-                    </marker>
-                    <marker id="twist-2" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
-                    <path d="M -1 6 L -1 -6 M 1 6 L 1,-6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
-                    </marker>
-                    <marker id="twist-3" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
-                    <path d="M -1.2 6 L -1.2 -6 M 0 6 L 0 -6 M 1.2 6 L 1.2 -6" fill="#000" stroke="#000" stroke-width="0.7px"></path>
-                    </marker>
-                 </defs>
-                 ${twistMarkerLine("L 30 30 M 30 30 L 40 40", southEast)}
-                 ${twistMarkerLine("L 10 30 M 10 30 L  0 40", southWest)}
-                 ${twistMarkerLine("L 10 10 M 10 10 L  0  0", northWest)}
-                 ${twistMarkerLine("L 30 10 M 30 10 L 40  0", northEast)}
+                   ${twistMarkerLine("twist-1",`${t1}` )}
+                   ${twistMarkerLine("twist-2",`${t2}` )}
+                   ${twistMarkerLine("twist-3",`${t3}` )}
+                   ${twistMarkerLine("twist-4",`${t4}` )}
+                </defs>
+                ${twistMarkerBase("L 30 30 M 30 30 L 40 40", southEast)}
+                ${twistMarkerBase("L 10 30 M 10 30 L  0 40", southWest)}
+                ${twistMarkerBase("L 10 10 M 10 10 L  0  0", northWest)}
+                ${twistMarkerBase("L 30 10 M 30 10 L 40  0", northEast)}
                  
-           
             <g transform="scale(2,2)">
             <g transform="translate(10,10)">
               ${PairSvg.shapes(displayStitch.toLowerCase())}
@@ -381,7 +386,6 @@ const GF_Random = {
             figure.append(threadSvg);
 
             displayElement.appendChild(figure);
-            displayElement.appendChild(twistMarkSvg);
             displayElement.appendChild(colorCodeSvg);
             displayElement.innerHTML += "&nbsp;" + "&nbsp;" + displayStitch;
             displayElement.innerHTML += "<br>";

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -326,14 +326,14 @@ const GF_Random = {
 
             displayStitch = GF_Random.stitchArray[i];
 
-            // copied from newLegendStitch, as "document.body.appendChild(figure)" does not clean up previous result, and picts to large
-            // without "figcaption"
+            // Copied from newLegendStitch, as "document.body.appendChild(figure)" does not clean up previous result, and picts to large.
+            // Without "figcaption", and with much other changes.
 
             let containerWidth = 60;
             let containerHeight = Math.max(60, displayStitch.length * 10);
 
             threadSvg = GF_svgP2T.newSVG(containerWidth,containerHeight);
-            // Overrule viewbox settings from newSVG. Necessary to line out on bottom of colorcode-element.
+            // Overrule viewbox settings from newSVG. Also necessary to line out on bottom of colorcode-element.
             threadSvg.setAttribute("viewBox", "-10 -10 " + (containerWidth + 12) + " " + (containerHeight + 12));
             GF_svgP2T.newStitch(displayStitch, 0,0, threadSvg,containerWidth,containerHeight);
             GF_svgP2T.addThreadClasses(threadSvg);          // this gives the lines their color
@@ -343,11 +343,13 @@ const GF_Random = {
             southWest = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("R","")).length.toString();
             northEast = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("L","")).length.toString();
             northWest = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("R","")).length.toString();
+            // User-input is limited to max 5; programmers-input to max 8. Because of view-box definition we show a maximum of 5 dashes.
             if (southEast > 5) {southEast = 5}
             if (southWest > 5) {southWest = 5}
             if (northEast > 5) {northEast = 5}
             if (northWest > 5) {northWest = 5}
 
+            // note: these dashes have to fit in the viewbox defined at twistMarkerLine.
             let t1 = "M 0.0 6 L 0.0 -6";
             let t2 = t1 + " M 5.0 6 L 5.0 -6";
             let t3 = t2 + " M 2.5 6 L 2.5-6";
@@ -357,7 +359,7 @@ const GF_Random = {
             function twistMarkerBase(path,swne) {
                 return `<path d="M 26 26 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
             }
-            function twistMarkerLine(twistId, path) {
+            function twistMarkerDash(twistId, path) {
                 return `<marker id="${twistId}" viewBox="-6 -6 12 12" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
                     <path d="${path}" fill="#000" stroke="#000" stroke-width="0.8px"></path>
                     </marker>`
@@ -366,15 +368,15 @@ const GF_Random = {
             // copied from GF_sttches.setcolorcode()
             colorCodeSvg = document.createElement("colorCodeSvg");
 
-            // the middle of the base-path has to be at least 10 units of the centre, else to close to colorcode-block
+            // the middle of the base-path has to be at least 10 units of the centre, else to close to colourcode-block
             colorCodeSvg.innerHTML = `
                 <svg width="50px" height="50px" fill="none">
                 <defs>
-                   ${twistMarkerLine("twist-1",`${t1}` )}
-                   ${twistMarkerLine("twist-2",`${t2}` )}
-                   ${twistMarkerLine("twist-3",`${t3}` )}
-                   ${twistMarkerLine("twist-4",`${t4}` )}
-                   ${twistMarkerLine("twist-5",`${t5}` )}
+                   ${twistMarkerDash("twist-1",`${t1}` )}
+                   ${twistMarkerDash("twist-2",`${t2}` )}
+                   ${twistMarkerDash("twist-3",`${t3}` )}
+                   ${twistMarkerDash("twist-4",`${t4}` )}
+                   ${twistMarkerDash("twist-5",`${t5}` )}
                 </defs>
                 ${twistMarkerBase("L 36 36 M 36 36 L 52 52", southEast)}
                 ${twistMarkerBase("L 16 36 M 16 36 L  0 52", southWest)}
@@ -398,7 +400,6 @@ const GF_Random = {
 
         }
     },
-
 
     makeRandomStitchList(stitchesRequired, maxCrosses, maxTwistsBetweenCrosses, maxTwistsBefore, maxTwistsAfter) {
         // The function can be called with or without attributes.

--- a/docs/js/stitch-gallery.js
+++ b/docs/js/stitch-gallery.js
@@ -329,11 +329,16 @@ const GF_Random = {
             // copied from newLegendStitch, as "document.body.appendChild(figure)" does not clean up previous result, and picts to large
             // without "figcaption"
 
-            threadSvg = GF_svgP2T.newSVG(40,60);
-            GF_svgP2T.newStitch(displayStitch, 0,0, threadSvg,40,60);
+            let containerWidth = 60;
+            let containerHeight = Math.max(60, displayStitch.length * 10);
+
+            threadSvg = GF_svgP2T.newSVG(containerWidth,containerHeight);
+            // Overrule viewbox settings from newSVG. Necessary to line out on bottom of colorcode-element.
+            threadSvg.setAttribute("viewBox", "-10 -10 " + (containerWidth + 12) + " " + (containerHeight + 12));
+            GF_svgP2T.newStitch(displayStitch, 0,0, threadSvg,containerWidth,containerHeight);
             GF_svgP2T.addThreadClasses(threadSvg);          // this gives the lines their color
 
-            // set variabeles for twistmarks
+            // set variables for twistmarks
             southEast = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("L","")).length.toString();
             southWest = ((displayStitch.substring(displayStitch.lastIndexOf("C")+1)).replaceAll("R","")).length.toString();
             northEast = ((displayStitch.substring(0, displayStitch.indexOf("C"))).replaceAll("L","")).length.toString();
@@ -343,18 +348,18 @@ const GF_Random = {
             if (northEast > 5) {northEast = 5}
             if (northWest > 5) {northWest = 5}
 
-            let t1 = "M -1.25 6 L -1.25 -6";
-            let t2 = t1 + " " + "M -0.5 6 L -0.5 -6" ;
-            let t3 = t2 + " " + "M 0.25 6 L 0.25 -6" ;
-            let t4 = t3 + " " + "M 1 6 L 1 -6" ;
-            let t5 = t4 + " " + "M 1.75 6 L 1.75 -6" ;
+            let t1 = "M 0.0 6 L 0.0 -6";
+            let t2 = t1 + " M 5.0 6 L 5.0 -6";
+            let t3 = t2 + " M 2.5 6 L 2.5-6";
+            let t4 = t3 + " M -2.5 6 L -2.5 -6";
+            let t5 = t4 + " M -5.0 6 L -5.0 -6";
 
             function twistMarkerBase(path,swne) {
                 return `<path d="M 26 26 ${path}" style="stroke: #000; stroke-width: 1.7px; marker-mid: url('#twist-${swne}');"></path>`;
             }
             function twistMarkerLine(twistId, path) {
-                return `<marker id="${twistId}" viewBox="-2 -2 4 4" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
-                    <path d="${path}" fill="#000" stroke="#000" stroke-width="0.5px"></path>
+                return `<marker id="${twistId}" viewBox="-6 -6 12 12" markerWidth="9" markerHeight="9" orient="auto" markerUnits="userSpaceOnUse">
+                    <path d="${path}" fill="#000" stroke="#000" stroke-width="0.8px"></path>
                     </marker>`
             }
 

--- a/docs/random-stitches/test-offline.html
+++ b/docs/random-stitches/test-offline.html
@@ -87,7 +87,7 @@
         </div>
 
         <div>
-        <p>Here the simple version, these are not cleaned.</p>
+        <p>Here the simple version. Just the array.</p>
         <p id="random0"></p>
         <p id="random1"></p>
         <p id="random2"></p>


### PR DESCRIPTION
Fixes issue #285 .

## Description / purpose  of the changes
The standard colorcode-element is defined as stitches starting and ending with "C". 
The randomlist generates stitches that can start and end with twists. 
For clearity, we have added these twistmarks to the colorcode-element.

## Notify
@d-bl/gf 